### PR TITLE
NAS-134628 / 25.04-RC.1 / bump from 7.4.2 to 7.4.3 (by yocalebo)

### DIFF
--- a/pull.sh
+++ b/pull.sh
@@ -1,6 +1,6 @@
 #!/bin/bash -ex
 VERSION=7.4
-REVISION=2
+REVISION=3
 
 wget http://deb.debian.org/debian/pool/main/s/smartmontools/smartmontools_$VERSION-$REVISION.debian.tar.xz
 tar xf smartmontools_$VERSION-$REVISION.debian.tar.xz


### PR DESCRIPTION
Bump to 7.4.3 to fix builds

Original PR: https://github.com/truenas/smartmontools/pull/6
Jira URL: https://ixsystems.atlassian.net/browse/NAS-134628